### PR TITLE
Feat: Add quests and monthly challenges

### DIFF
--- a/src/main/java/com/testingpractice/duoclonebackend/constants/pathConstants.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/constants/pathConstants.java
@@ -11,6 +11,7 @@ public class pathConstants {
   public static final String USERS = API_V1 + "/users";
   public static final String LESSONS = API_V1 + "/lessons";
   public static final String SECTIONS = API_V1 + "/sections";
+  public static final String QUESTS = API_V1 + "/quests";
 
   public static final String EXERCISES_ATTEMPTS = EXERCISES + "/attempts";
   public static final String LESSONS_COMPLETIONS = LESSONS + "/completions";
@@ -18,6 +19,7 @@ public class pathConstants {
   // ----------------------------- GET REQUESTS -----------------------------
   public static final String GET_USER_COURSE_PROGRESS = "/progress/{courseId}/{userId}";
   public static final String GET_USER_BY_ID = "/{userId}";
+  public static final String GET_QUESTS_BY_USER = "/{userId}";
 
   // ===== GET DTO LIST BY PARENT =====
   public static final String GET_UNITS_BY_SECTION = "/{sectionId}/units";

--- a/src/main/java/com/testingpractice/duoclonebackend/constants/pathConstants.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/constants/pathConstants.java
@@ -12,6 +12,7 @@ public class pathConstants {
   public static final String LESSONS = API_V1 + "/lessons";
   public static final String SECTIONS = API_V1 + "/sections";
   public static final String QUESTS = API_V1 + "/quests";
+  public static final String MONTHLY_CHALLENGES = API_V1 + "/monthly-challenges";
 
   public static final String EXERCISES_ATTEMPTS = EXERCISES + "/attempts";
   public static final String LESSONS_COMPLETIONS = LESSONS + "/completions";
@@ -20,6 +21,7 @@ public class pathConstants {
   public static final String GET_USER_COURSE_PROGRESS = "/progress/{courseId}/{userId}";
   public static final String GET_USER_BY_ID = "/{userId}";
   public static final String GET_QUESTS_BY_USER = "/{userId}";
+  public static final String GET_MONTHLY_CHALLENGE_BY_USER = "/{userId}";
 
   // ===== GET DTO LIST BY PARENT =====
   public static final String GET_UNITS_BY_SECTION = "/{sectionId}/units";

--- a/src/main/java/com/testingpractice/duoclonebackend/constants/pathConstants.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/constants/pathConstants.java
@@ -12,8 +12,8 @@ public class pathConstants {
   public static final String LESSONS = API_V1 + "/lessons";
   public static final String SECTIONS = API_V1 + "/sections";
 
-  public static final String EXERCISES_ATTEMPTS = API_V1 + EXERCISES + "/attempts";
-  public static final String LESSONS_COMPLETIONS = API_V1 + LESSONS + "/completions";
+  public static final String EXERCISES_ATTEMPTS = EXERCISES + "/attempts";
+  public static final String LESSONS_COMPLETIONS = LESSONS + "/completions";
 
   // ----------------------------- GET REQUESTS -----------------------------
   public static final String GET_USER_COURSE_PROGRESS = "/progress/{courseId}/{userId}";

--- a/src/main/java/com/testingpractice/duoclonebackend/domain/controller/MonthlyChallengeController.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/domain/controller/MonthlyChallengeController.java
@@ -1,0 +1,23 @@
+package com.testingpractice.duoclonebackend.domain.controller;
+
+
+import com.testingpractice.duoclonebackend.constants.pathConstants;
+import com.testingpractice.duoclonebackend.dto.QuestResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(pathConstants.MONTHLY_CHALLENGES)
+public class MonthlyChallengeController {
+
+    @GetMapping(pathConstants.GET_MONTHLY_CHALLENGE_BY_USER)
+    public QuestResponse getMonthlyChallenge (@PathVariable Integer userId) {
+
+    }
+
+
+}

--- a/src/main/java/com/testingpractice/duoclonebackend/domain/controller/MonthlyChallengeController.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/domain/controller/MonthlyChallengeController.java
@@ -3,6 +3,7 @@ package com.testingpractice.duoclonebackend.domain.controller;
 
 import com.testingpractice.duoclonebackend.constants.pathConstants;
 import com.testingpractice.duoclonebackend.dto.QuestResponse;
+import com.testingpractice.duoclonebackend.service.MonthlyChallengeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -14,9 +15,11 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping(pathConstants.MONTHLY_CHALLENGES)
 public class MonthlyChallengeController {
 
+    private final MonthlyChallengeService monthlyChallengeService;
+
     @GetMapping(pathConstants.GET_MONTHLY_CHALLENGE_BY_USER)
     public QuestResponse getMonthlyChallenge (@PathVariable Integer userId) {
-
+        return monthlyChallengeService.getMonthlyChallengeForUser(userId);
     }
 
 

--- a/src/main/java/com/testingpractice/duoclonebackend/domain/controller/QuestController.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/domain/controller/QuestController.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
-
 import java.util.List;
 
 @RestController

--- a/src/main/java/com/testingpractice/duoclonebackend/domain/controller/QuestController.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/domain/controller/QuestController.java
@@ -1,0 +1,3 @@
+package com.testingpractice.duoclonebackend.domain.controller;
+
+public class QuestController {}

--- a/src/main/java/com/testingpractice/duoclonebackend/domain/controller/QuestController.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/domain/controller/QuestController.java
@@ -1,3 +1,30 @@
 package com.testingpractice.duoclonebackend.domain.controller;
 
-public class QuestController {}
+import com.testingpractice.duoclonebackend.constants.pathConstants;
+import com.testingpractice.duoclonebackend.dto.QuestResponse;
+import com.testingpractice.duoclonebackend.service.QuestService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping(pathConstants.QUESTS)
+public class QuestController {
+
+    private final QuestService questService;
+
+    @GetMapping(pathConstants.GET_QUESTS_BY_USER)
+    public List<QuestResponse> getQuestsByUserId (
+            @PathVariable Integer userId
+    ) {
+        return questService.getQuestsForUser(userId);
+    }
+
+
+
+}

--- a/src/main/java/com/testingpractice/duoclonebackend/dto/QuestResponse.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/dto/QuestResponse.java
@@ -1,0 +1,11 @@
+package com.testingpractice.duoclonebackend.dto;
+
+public record QuestResponse (
+        String title,
+        String code,
+        Integer progress,
+        Integer total,
+        boolean active
+) {
+
+}

--- a/src/main/java/com/testingpractice/duoclonebackend/dto/QuestResponse.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/dto/QuestResponse.java
@@ -1,7 +1,6 @@
 package com.testingpractice.duoclonebackend.dto;
 
 public record QuestResponse (
-        String title,
         String code,
         Integer progress,
         Integer total,

--- a/src/main/java/com/testingpractice/duoclonebackend/entity/MonthlyChallengeDefinition.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/entity/MonthlyChallengeDefinition.java
@@ -1,0 +1,27 @@
+package com.testingpractice.duoclonebackend.entity;
+
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Entity
+@Data
+public class MonthlyChallengeDefinition {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Integer id;
+
+    @Column(name = "code")
+    private String code;
+
+    @Column(name = "target")
+    private Integer target;
+
+    @Column(name = "reward_points")
+    private Integer rewardPoints;
+
+    @Column(name = "active")
+    private boolean active;
+
+}

--- a/src/main/java/com/testingpractice/duoclonebackend/entity/QuestDefinition.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/entity/QuestDefinition.java
@@ -1,0 +1,29 @@
+package com.testingpractice.duoclonebackend.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Entity
+@Data
+public class QuestDefinition {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.AUTO)
+    private Integer id;
+
+    @Column(name = "code")
+    private String code;
+
+    @Column(name = "target")
+    private Integer target;
+
+    @Column(name = "reward_points")
+    private Integer rewardPoints;
+
+    @Column(name = "active")
+    private boolean active;
+
+
+
+
+}

--- a/src/main/java/com/testingpractice/duoclonebackend/entity/UserDailyQuest.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/entity/UserDailyQuest.java
@@ -1,0 +1,32 @@
+package com.testingpractice.duoclonebackend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.sql.Timestamp;
+
+@Entity
+@Table(name = "user_daily_quest")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserDailyQuest {
+
+    @EmbeddedId private UserDailyQuestId id;
+    @Column(nullable = false)
+    private Integer progress = 0;
+
+    @Column(name = "completed_at")
+    private Timestamp completedAt;
+
+    @Column(name = "reward_claimed", nullable = false)
+    private boolean rewardClaimed = false;
+
+}

--- a/src/main/java/com/testingpractice/duoclonebackend/entity/UserDailyQuestId.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/entity/UserDailyQuestId.java
@@ -35,4 +35,5 @@ public class UserDailyQuestId implements Serializable {
     public int hashCode() {
         return Objects.hash(userId, questDefId, date);
     }
+
 }

--- a/src/main/java/com/testingpractice/duoclonebackend/entity/UserDailyQuestId.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/entity/UserDailyQuestId.java
@@ -1,0 +1,36 @@
+package com.testingpractice.duoclonebackend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Embeddable
+public class UserDailyQuestId implements Serializable {
+
+    @Column(name = "user_id")
+    private Integer userId;
+
+    @Column(name = "quest_def_id")
+    private Integer questDefId;
+
+    @Column(name = "date")
+    private LocalDate date;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UserDailyQuestId)) return false;
+        UserDailyQuestId that = (UserDailyQuestId) o;
+        return Objects.equals(userId, that.userId) &&
+                Objects.equals(questDefId, that.questDefId) &&
+                Objects.equals(date, that.date);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, questDefId, date);
+    }
+}

--- a/src/main/java/com/testingpractice/duoclonebackend/entity/UserDailyQuestId.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/entity/UserDailyQuestId.java
@@ -2,12 +2,14 @@ package com.testingpractice.duoclonebackend.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
+import lombok.Data;
 
 import java.io.Serializable;
 import java.time.LocalDate;
 import java.util.Objects;
 
 @Embeddable
+@Data
 public class UserDailyQuestId implements Serializable {
 
     @Column(name = "user_id")

--- a/src/main/java/com/testingpractice/duoclonebackend/entity/UserMonthlyChallenge.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/entity/UserMonthlyChallenge.java
@@ -1,3 +1,32 @@
 package com.testingpractice.duoclonebackend.entity;
+import jakarta.persistence.Column;
+import jakarta.persistence.EmbeddedId;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-public class UserMonthlyChallenge {}
+import java.sql.Timestamp;
+
+@Entity
+@Table(name = "user_monthly_challenge")
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserMonthlyChallenge {
+
+    @EmbeddedId
+    private UserMonthlyChallengeId id;
+
+    @Column(nullable = false)
+    private Integer progress = 0;
+
+    @Column(name = "completed_at")
+    private Timestamp completedAt;
+
+    @Column(name = "reward_claimed", nullable = false)
+    private boolean rewardClaimed = false;
+}

--- a/src/main/java/com/testingpractice/duoclonebackend/entity/UserMonthlyChallenge.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/entity/UserMonthlyChallenge.java
@@ -1,0 +1,3 @@
+package com.testingpractice.duoclonebackend.entity;
+
+public class UserMonthlyChallenge {}

--- a/src/main/java/com/testingpractice/duoclonebackend/entity/UserMonthlyChallengeId.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/entity/UserMonthlyChallengeId.java
@@ -1,0 +1,42 @@
+package com.testingpractice.duoclonebackend.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import lombok.Data;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+import java.util.Objects;
+
+@Embeddable
+@Data
+public class UserMonthlyChallengeId implements Serializable {
+
+    @Column(name = "user_id")
+    private Integer userId;
+
+    @Column(name = "challenge_def_id")
+    private Integer challengeDefId;
+
+    @Column(name = "year")
+    private Integer year;
+
+    @Column(name = "month")
+    private Integer month;
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof UserMonthlyChallengeId)) return false;
+        UserMonthlyChallengeId that = (UserMonthlyChallengeId) o;
+        return Objects.equals(userId, that.userId) &&
+                Objects.equals(challengeDefId, that.challengeDefId) &&
+                Objects.equals(year, that.year) &&
+                Objects.equals(month, that.month);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(userId, challengeDefId, year, month);
+    }
+}

--- a/src/main/java/com/testingpractice/duoclonebackend/enums/QuestCode.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/enums/QuestCode.java
@@ -1,0 +1,9 @@
+package com.testingpractice.duoclonebackend.enums;
+
+public enum QuestCode {
+
+    STREAK,
+    PERFECT,
+    ACCURACY
+
+}

--- a/src/main/java/com/testingpractice/duoclonebackend/enums/QuestCode.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/enums/QuestCode.java
@@ -4,6 +4,7 @@ public enum QuestCode {
 
     STREAK,
     PERFECT,
-    ACCURACY
+    ACCURACY,
+    COMPLETE_QUESTS
 
 }

--- a/src/main/java/com/testingpractice/duoclonebackend/exception/ErrorCode.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/exception/ErrorCode.java
@@ -9,6 +9,8 @@ public enum ErrorCode {
   SECTION_NOT_FOUND(HttpStatus.NOT_FOUND, "Section not found"),
   PROGRESS_NOT_FOUND(HttpStatus.NOT_FOUND, "User progress not found"),
   EXERCISES_NOT_FOUND(HttpStatus.NOT_FOUND, "Exercises are null or empty for given lesson"),
+  USER_DAILY_QUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "User daily quest not found"),
+  QUEST_NOT_FOUND(HttpStatus.NOT_FOUND, "Quest was not found"),
   COURSE_END(HttpStatus.BAD_REQUEST, "No next lesson — course complete"),
   OPTION_NOT_FOUND(HttpStatus.NOT_FOUND, "No option found for the submitted option");
 

--- a/src/main/java/com/testingpractice/duoclonebackend/repository/MonthlyChallengeDefinitionRepository.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/repository/MonthlyChallengeDefinitionRepository.java
@@ -1,0 +1,10 @@
+package com.testingpractice.duoclonebackend.repository;
+
+import com.testingpractice.duoclonebackend.entity.MonthlyChallengeDefinition;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MonthlyChallengeDefinitionRepository extends JpaRepository<MonthlyChallengeDefinition, Integer> {
+
+
+
+}

--- a/src/main/java/com/testingpractice/duoclonebackend/repository/MonthlyChallengeDefinitionRepository.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/repository/MonthlyChallengeDefinitionRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface MonthlyChallengeDefinitionRepository extends JpaRepository<MonthlyChallengeDefinition, Integer> {
 
 
-
+    MonthlyChallengeDefinition findByActive(boolean active);
 }

--- a/src/main/java/com/testingpractice/duoclonebackend/repository/QuestDefinitionRepository.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/repository/QuestDefinitionRepository.java
@@ -4,9 +4,14 @@ import com.testingpractice.duoclonebackend.entity.QuestDefinition;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface QuestDefinitionRepository extends JpaRepository<QuestDefinition, Integer> {
 
 
     List<QuestDefinition> findAllByActive(boolean active);
+
+    Optional<QuestDefinition> findByCode(String code);
+
+    Optional<QuestDefinition> findByCodeAndActiveTrue(String code);
 }

--- a/src/main/java/com/testingpractice/duoclonebackend/repository/QuestDefinitionRepository.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/repository/QuestDefinitionRepository.java
@@ -1,0 +1,11 @@
+package com.testingpractice.duoclonebackend.repository;
+
+import com.testingpractice.duoclonebackend.entity.QuestDefinition;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestDefinitionRepository extends JpaRepository<QuestDefinition, Integer> {
+
+
+
+
+}

--- a/src/main/java/com/testingpractice/duoclonebackend/repository/QuestDefinitionRepository.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/repository/QuestDefinitionRepository.java
@@ -3,9 +3,10 @@ package com.testingpractice.duoclonebackend.repository;
 import com.testingpractice.duoclonebackend.entity.QuestDefinition;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface QuestDefinitionRepository extends JpaRepository<QuestDefinition, Integer> {
 
 
-
-
+    List<QuestDefinition> findAllByActive(boolean active);
 }

--- a/src/main/java/com/testingpractice/duoclonebackend/repository/UserDailyQuestRepository.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/repository/UserDailyQuestRepository.java
@@ -7,10 +7,11 @@ import org.springframework.data.jpa.repository.Modifying;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 public interface UserDailyQuestRepository extends JpaRepository<UserDailyQuest, UserDailyQuestId> {
 
     List<UserDailyQuest> findAllByIdUserIdAndIdDate(Integer userId, LocalDate date);
-
+    Optional<UserDailyQuest> findByIdUserIdAndIdQuestDefIdAndIdDate(Integer userId, Integer questDefId, LocalDate date);
 
 }

--- a/src/main/java/com/testingpractice/duoclonebackend/repository/UserDailyQuestRepository.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/repository/UserDailyQuestRepository.java
@@ -1,0 +1,7 @@
+package com.testingpractice.duoclonebackend.repository;
+
+import com.testingpractice.duoclonebackend.entity.UserDailyQuest;
+import com.testingpractice.duoclonebackend.entity.UserDailyQuestId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserDailyQuestRepository extends JpaRepository<UserDailyQuest, UserDailyQuestId> {}

--- a/src/main/java/com/testingpractice/duoclonebackend/repository/UserDailyQuestRepository.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/repository/UserDailyQuestRepository.java
@@ -3,5 +3,14 @@ package com.testingpractice.duoclonebackend.repository;
 import com.testingpractice.duoclonebackend.entity.UserDailyQuest;
 import com.testingpractice.duoclonebackend.entity.UserDailyQuestId;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 
-public interface UserDailyQuestRepository extends JpaRepository<UserDailyQuest, UserDailyQuestId> {}
+import java.time.LocalDate;
+import java.util.List;
+
+public interface UserDailyQuestRepository extends JpaRepository<UserDailyQuest, UserDailyQuestId> {
+
+    List<UserDailyQuest> findAllByIdUserIdAndIdDate(Integer userId, LocalDate date);
+
+
+}

--- a/src/main/java/com/testingpractice/duoclonebackend/repository/UserMonthlyChallengeRepository.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/repository/UserMonthlyChallengeRepository.java
@@ -1,0 +1,10 @@
+package com.testingpractice.duoclonebackend.repository;
+
+import com.testingpractice.duoclonebackend.entity.UserMonthlyChallenge;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserMonthlyChallengeRepository extends JpaRepository<UserMonthlyChallenge, Integer> {
+
+
+
+}

--- a/src/main/java/com/testingpractice/duoclonebackend/repository/UserMonthlyChallengeRepository.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/repository/UserMonthlyChallengeRepository.java
@@ -1,9 +1,10 @@
 package com.testingpractice.duoclonebackend.repository;
 
 import com.testingpractice.duoclonebackend.entity.UserMonthlyChallenge;
+import com.testingpractice.duoclonebackend.entity.UserMonthlyChallengeId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UserMonthlyChallengeRepository extends JpaRepository<UserMonthlyChallenge, Integer> {
+public interface UserMonthlyChallengeRepository extends JpaRepository<UserMonthlyChallenge, UserMonthlyChallengeId> {
 
 
 

--- a/src/main/java/com/testingpractice/duoclonebackend/service/LessonCompletionServiceImpl.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/service/LessonCompletionServiceImpl.java
@@ -6,6 +6,7 @@ import com.testingpractice.duoclonebackend.entity.ExerciseAttempt;
 import com.testingpractice.duoclonebackend.entity.Lesson;
 import com.testingpractice.duoclonebackend.entity.User;
 import com.testingpractice.duoclonebackend.entity.UserCourseProgress;
+import com.testingpractice.duoclonebackend.enums.QuestCode;
 import com.testingpractice.duoclonebackend.mapper.LessonMapper;
 import com.testingpractice.duoclonebackend.mapper.UserCourseProgressMapper;
 import com.testingpractice.duoclonebackend.repository.LessonCompletionRepository;
@@ -31,6 +32,7 @@ public class LessonCompletionServiceImpl implements LessonCompletionService{
     private final UserRepository userRepository;
     private final LessonMapper lessonMapper;
     private final UserCourseProgressMapper userCourseProgressMapper;
+    private final QuestService questService;
 
     @Transactional
     public LessonCompleteResponse getCompletedLesson (Integer lessonId, Integer userId, Integer courseId) {
@@ -59,6 +61,8 @@ public class LessonCompletionServiceImpl implements LessonCompletionService{
 
         Integer completedLessonsInCourse = getCompletedLessonsInCourse(userId, courseId);
 
+        updateQuests(userId, lessonAccuracy, newStreakCount);
+
         return new LessonCompleteResponse(
                 scoreForLesson,
                 user.getPoints(),
@@ -76,6 +80,25 @@ public class LessonCompletionServiceImpl implements LessonCompletionService{
 
         if (completedLessonsInCourse == null) return 0;
         else return completedLessonsInCourse;
+
+    }
+
+    private void updateQuests (Integer userId, Integer lessonAccuracy, NewStreakCount newStreakCount) {
+
+        if (lessonAccuracy == 100) {
+            questService.updateQuestProgress(userId, QuestCode.PERFECT);
+        }
+
+        if (lessonAccuracy > 90) {
+            questService.updateQuestProgress(userId, QuestCode.ACCURACY);
+        }
+
+        Integer prev = newStreakCount.oldCount();
+        Integer next = newStreakCount.newCount();
+
+        if (next > prev) {
+            questService.updateQuestProgress(userId, QuestCode.STREAK);
+        }
 
     }
 

--- a/src/main/java/com/testingpractice/duoclonebackend/service/MonthlyChallengeService.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/service/MonthlyChallengeService.java
@@ -8,6 +8,7 @@ import com.testingpractice.duoclonebackend.exception.ApiException;
 import com.testingpractice.duoclonebackend.exception.ErrorCode;
 import com.testingpractice.duoclonebackend.repository.MonthlyChallengeDefinitionRepository;
 import com.testingpractice.duoclonebackend.repository.UserMonthlyChallengeRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,6 +22,7 @@ public class MonthlyChallengeService {
     private final MonthlyChallengeDefinitionRepository monthlyChallengeDefinitionRepository;
     private final UserMonthlyChallengeRepository userMonthlyChallengeRepository;
 
+    @Transactional
     public QuestResponse getMonthlyChallengeForUser (Integer userId) {
 
        ZoneId tz = ZoneId.systemDefault();
@@ -35,6 +37,25 @@ public class MonthlyChallengeService {
 
    }
 
+   @Transactional
+   public void addChallengeProgress (Integer userId) {
+
+       ZoneId tz = ZoneId.systemDefault();
+       LocalDate today = LocalDate.now(tz);
+       int year = today.getYear();
+       int month = today.getMonthValue();
+
+       MonthlyChallengeDefinition monthlyChallengeDefinition = monthlyChallengeDefinitionRepository.findByActive(true);
+       UserMonthlyChallenge userMonthlyChallenge = getUserMCOrElseCreateNew(monthlyChallengeDefinition, userId, year, month);
+
+       if (userMonthlyChallenge.getProgress() < monthlyChallengeDefinition.getTarget()) {
+           userMonthlyChallenge.setProgress(userMonthlyChallenge.getProgress() +  1);
+           userMonthlyChallengeRepository.save(userMonthlyChallenge);
+       }
+
+   }
+
+   @Transactional
    public UserMonthlyChallenge getUserMCOrElseCreateNew (MonthlyChallengeDefinition monthlyChallengeDefinition, Integer userId, int year, int month) {
 
        UserMonthlyChallengeId id = new UserMonthlyChallengeId();

--- a/src/main/java/com/testingpractice/duoclonebackend/service/MonthlyChallengeService.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/service/MonthlyChallengeService.java
@@ -1,0 +1,59 @@
+package com.testingpractice.duoclonebackend.service;
+
+import com.testingpractice.duoclonebackend.dto.QuestResponse;
+import com.testingpractice.duoclonebackend.entity.MonthlyChallengeDefinition;
+import com.testingpractice.duoclonebackend.entity.UserMonthlyChallenge;
+import com.testingpractice.duoclonebackend.entity.UserMonthlyChallengeId;
+import com.testingpractice.duoclonebackend.exception.ApiException;
+import com.testingpractice.duoclonebackend.exception.ErrorCode;
+import com.testingpractice.duoclonebackend.repository.MonthlyChallengeDefinitionRepository;
+import com.testingpractice.duoclonebackend.repository.UserMonthlyChallengeRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+@Service
+@RequiredArgsConstructor
+public class MonthlyChallengeService {
+
+    private final MonthlyChallengeDefinitionRepository monthlyChallengeDefinitionRepository;
+    private final UserMonthlyChallengeRepository userMonthlyChallengeRepository;
+
+    public QuestResponse getMonthlyChallengeForUser (Integer userId) {
+
+       ZoneId tz = ZoneId.systemDefault();
+       LocalDate today = LocalDate.now(tz);
+       int year = today.getYear();
+       int month = today.getMonthValue();
+
+       MonthlyChallengeDefinition monthlyChallengeDefinition = monthlyChallengeDefinitionRepository.findByActive(true);
+
+       UserMonthlyChallenge userMonthlyChallenge = getUserMCOrElseCreateNew(monthlyChallengeDefinition, userId, year, month);
+       return new QuestResponse(monthlyChallengeDefinition.getCode(), userMonthlyChallenge.getProgress(), monthlyChallengeDefinition.getTarget(), monthlyChallengeDefinition.isActive());
+
+   }
+
+   public UserMonthlyChallenge getUserMCOrElseCreateNew (MonthlyChallengeDefinition monthlyChallengeDefinition, Integer userId, int year, int month) {
+
+       UserMonthlyChallengeId id = new UserMonthlyChallengeId();
+       id.setUserId(userId);
+       id.setChallengeDefId(monthlyChallengeDefinition.getId());
+       id.setYear(year);
+       id.setMonth(month);
+
+       if (!userMonthlyChallengeRepository.existsById(id)) {
+           UserMonthlyChallenge umq = new UserMonthlyChallenge();
+           umq.setId(id);
+           umq.setProgress(0);
+           umq.setRewardClaimed(false);
+           userMonthlyChallengeRepository.save(umq);
+           return umq;
+       } else {
+           return userMonthlyChallengeRepository.findById(id).orElseThrow(() -> new ApiException(ErrorCode.USER_DAILY_QUEST_NOT_FOUND));
+       }
+
+   }
+
+}

--- a/src/main/java/com/testingpractice/duoclonebackend/service/QuestService.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/service/QuestService.java
@@ -1,0 +1,87 @@
+package com.testingpractice.duoclonebackend.service;
+
+import com.testingpractice.duoclonebackend.dto.QuestResponse;
+import com.testingpractice.duoclonebackend.entity.QuestDefinition;
+import com.testingpractice.duoclonebackend.entity.UserDailyQuest;
+import com.testingpractice.duoclonebackend.entity.UserDailyQuestId;
+import com.testingpractice.duoclonebackend.repository.QuestDefinitionRepository;
+import com.testingpractice.duoclonebackend.repository.UserDailyQuestRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class QuestService {
+
+    private final QuestDefinitionRepository questDefinitionRepository;
+    private final UserDailyQuestRepository userDailyQuestRepository;
+
+    public List<QuestResponse> getQuestsForUser (Integer userId) {
+
+        ZoneId tz = ZoneId.systemDefault();
+        LocalDate today = LocalDate.now(tz);
+
+        List<QuestDefinition> questDefinitions = questDefinitionRepository.findAllByActive(true);
+
+        refreshDailyActiveQuests(userId, questDefinitions, today);
+
+        List<UserDailyQuest> userDailyQuests =
+                userDailyQuestRepository.findAllByIdUserIdAndIdDate(userId, today);
+
+        return parseToQuestionResponseList(questDefinitions, userDailyQuests);
+
+
+    }
+
+    public void checkQuestCompletionStatus (Integer userId) {
+
+
+
+    }
+
+    private List<QuestResponse> parseToQuestionResponseList (List<QuestDefinition> questDefinitions, List<UserDailyQuest> userDailyQuests) {
+
+        return userDailyQuests.stream()
+                .map(userDailyQuest -> {
+                    QuestDefinition questDefinition = questDefinitions.stream()
+                            .filter(definition -> definition.getId().equals(userDailyQuest.getId().getQuestDefId()))
+                            .findFirst()
+                            .orElseThrow();
+                    return new QuestResponse(
+                            questDefinition.getCode(),
+                            userDailyQuest.getProgress(),
+                            questDefinition.getTarget(),
+                            questDefinition.isActive()
+                    );
+                })
+                .toList();
+
+    }
+
+    private void refreshDailyActiveQuests (Integer userId, List<QuestDefinition> questDefinitions, LocalDate today) {
+
+
+        for (QuestDefinition questDefinition : questDefinitions) {
+            UserDailyQuestId id = new UserDailyQuestId();
+            id.setUserId(userId);
+            id.setQuestDefId(questDefinition.getId());
+            id.setDate(today);
+
+            if (!userDailyQuestRepository.existsById(id)) {
+                UserDailyQuest udq = new UserDailyQuest();
+                udq.setId(id);
+                udq.setProgress(0);
+                udq.setRewardClaimed(false);
+                userDailyQuestRepository.save(udq);
+            }
+        }
+
+
+    }
+
+
+}

--- a/src/main/java/com/testingpractice/duoclonebackend/service/QuestService.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/service/QuestService.java
@@ -4,14 +4,19 @@ import com.testingpractice.duoclonebackend.dto.QuestResponse;
 import com.testingpractice.duoclonebackend.entity.QuestDefinition;
 import com.testingpractice.duoclonebackend.entity.UserDailyQuest;
 import com.testingpractice.duoclonebackend.entity.UserDailyQuestId;
+import com.testingpractice.duoclonebackend.enums.QuestCode;
+import com.testingpractice.duoclonebackend.exception.ApiException;
+import com.testingpractice.duoclonebackend.exception.ErrorCode;
 import com.testingpractice.duoclonebackend.repository.QuestDefinitionRepository;
 import com.testingpractice.duoclonebackend.repository.UserDailyQuestRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -37,9 +42,25 @@ public class QuestService {
 
     }
 
-    public void checkQuestCompletionStatus (Integer userId) {
+    @Transactional
+    public void updateQuestProgress(Integer userId, QuestCode questCode) {
 
+        QuestDefinition questDefinition = questDefinitionRepository
+                .findByCodeAndActiveTrue(questCode.name())
+                .orElseThrow(() -> new ApiException(ErrorCode.QUEST_NOT_FOUND));
 
+        if (questDefinition != null) {
+            ZoneId tz = ZoneId.systemDefault();
+            LocalDate today = LocalDate.now(tz);
+
+            UserDailyQuest userDailyQuest = userDailyQuestRepository
+                    .findByIdUserIdAndIdQuestDefIdAndIdDate(userId, questDefinition.getId(), today)
+                    .orElseGet(() -> createNewUserDailyQuest(questDefinition, userId, today));
+
+            if (userDailyQuest.getProgress() < questDefinition.getTarget()) {
+                userDailyQuest.setProgress(userDailyQuest.getProgress() + 1);
+            }
+        }
 
     }
 
@@ -62,22 +83,30 @@ public class QuestService {
 
     }
 
-    private void refreshDailyActiveQuests (Integer userId, List<QuestDefinition> questDefinitions, LocalDate today) {
-
-
+    @Transactional
+    public void refreshDailyActiveQuests (Integer userId, List<QuestDefinition> questDefinitions, LocalDate today) {
         for (QuestDefinition questDefinition : questDefinitions) {
-            UserDailyQuestId id = new UserDailyQuestId();
-            id.setUserId(userId);
-            id.setQuestDefId(questDefinition.getId());
-            id.setDate(today);
+            createNewUserDailyQuest(questDefinition, userId, today);
+        }
+    }
 
-            if (!userDailyQuestRepository.existsById(id)) {
-                UserDailyQuest udq = new UserDailyQuest();
-                udq.setId(id);
-                udq.setProgress(0);
-                udq.setRewardClaimed(false);
-                userDailyQuestRepository.save(udq);
-            }
+    @Transactional
+    public UserDailyQuest createNewUserDailyQuest (QuestDefinition questDefinition, Integer userId, LocalDate today) {
+
+        UserDailyQuestId id = new UserDailyQuestId();
+        id.setUserId(userId);
+        id.setQuestDefId(questDefinition.getId());
+        id.setDate(today);
+
+        if (!userDailyQuestRepository.existsById(id)) {
+            UserDailyQuest udq = new UserDailyQuest();
+            udq.setId(id);
+            udq.setProgress(0);
+            udq.setRewardClaimed(false);
+            userDailyQuestRepository.save(udq);
+            return udq;
+        } else {
+            return userDailyQuestRepository.findById(id).orElseThrow(() -> new ApiException(ErrorCode.USER_DAILY_QUEST_NOT_FOUND));
         }
 
 

--- a/src/main/java/com/testingpractice/duoclonebackend/service/QuestService.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/service/QuestService.java
@@ -24,7 +24,9 @@ public class QuestService {
 
     private final QuestDefinitionRepository questDefinitionRepository;
     private final UserDailyQuestRepository userDailyQuestRepository;
+    private final MonthlyChallengeService monthlyChallengeService;
 
+    @Transactional
     public List<QuestResponse> getQuestsForUser (Integer userId) {
 
         ZoneId tz = ZoneId.systemDefault();
@@ -59,6 +61,7 @@ public class QuestService {
 
             if (userDailyQuest.getProgress() < questDefinition.getTarget()) {
                 userDailyQuest.setProgress(userDailyQuest.getProgress() + 1);
+                monthlyChallengeService.addChallengeProgress(userId);
             }
         }
 

--- a/src/main/java/com/testingpractice/duoclonebackend/service/StreakService.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/service/StreakService.java
@@ -2,6 +2,8 @@ package com.testingpractice.duoclonebackend.service;
 
 import com.testingpractice.duoclonebackend.dto.NewStreakCount;
 import com.testingpractice.duoclonebackend.entity.User;
+import com.testingpractice.duoclonebackend.enums.QuestCode;
+import jakarta.transaction.Transactional;
 import org.springframework.stereotype.Service;
 
 import java.sql.Timestamp;
@@ -12,14 +14,21 @@ import java.time.ZoneId;
 @Service
 public class StreakService {
 
+    private final QuestService questService;
+
+    public StreakService(QuestService questService) {
+        this.questService = questService;
+    }
+
+    @Transactional
     public NewStreakCount updateUserStreak (User user) {
 
         Timestamp lastSubmission = user.getLastSubmission();
         ZoneId tz = ZoneId.systemDefault();
         LocalDate today = LocalDate.now(tz);
 
-        int prev = user.getStreakLength();
-        int next = prev;
+        Integer prev = user.getStreakLength();
+        Integer next = prev;
 
         if (lastSubmission == null) {
             next = 1;
@@ -37,6 +46,12 @@ public class StreakService {
 
         user.setStreakLength(next);
         user.setLastSubmission(Timestamp.from(Instant.now()));
+
+        if (!(next.equals(prev))) {
+            questService.updateQuestProgress(user.getId(), QuestCode.STREAK);
+        }
+
+
 
         return new NewStreakCount(prev, next);
 

--- a/src/main/java/com/testingpractice/duoclonebackend/service/StreakService.java
+++ b/src/main/java/com/testingpractice/duoclonebackend/service/StreakService.java
@@ -14,13 +14,6 @@ import java.time.ZoneId;
 @Service
 public class StreakService {
 
-    private final QuestService questService;
-
-    public StreakService(QuestService questService) {
-        this.questService = questService;
-    }
-
-    @Transactional
     public NewStreakCount updateUserStreak (User user) {
 
         Timestamp lastSubmission = user.getLastSubmission();
@@ -46,12 +39,6 @@ public class StreakService {
 
         user.setStreakLength(next);
         user.setLastSubmission(Timestamp.from(Instant.now()));
-
-        if (!(next.equals(prev))) {
-            questService.updateQuestProgress(user.getId(), QuestCode.STREAK);
-        }
-
-
 
         return new NewStreakCount(prev, next);
 


### PR DESCRIPTION
- Add quests, quest types
- Create a new user quest progress entry if does not exist
- Current quests are streak, accuracy, and perfect lesson

- Add monthly challenge
- Monthly challenge follows mostly same logic as daily quests